### PR TITLE
Force slice indices to be integers

### DIFF
--- a/lib/data_augmentation.py
+++ b/lib/data_augmentation.py
@@ -29,10 +29,10 @@ def image_transform(img, crop_x, crop_y, crop_loc=None, color_tint=None):
 def crop_center(im, new_height, new_width):
     height = im.shape[0]  # Get dimensions
     width = im.shape[1]
-    left = (width - new_width) / 2
-    top = (height - new_height) / 2
-    right = (width + new_width) / 2
-    bottom = (height + new_height) / 2
+    left = (width - new_width) // 2
+    top = (height - new_height) // 2
+    right = (width + new_width) // 2
+    bottom = (height + new_height) // 2
     return im[top:bottom, left:right]
 
 


### PR DESCRIPTION
By following your installation instructions and creating a Python 3 environment, I ended up into having trouble with the `crop_center` function in `data_augmentation.py`. More specifically, the indices `top`, `bottom`, `left` and `right` are calculated using the floating-point division operator `/`.

```
Compiling training function
Traceback (most recent call last):
  File "/home/dlvm/code/3D-R2N2/lib/data_process.py", line 24, in func_wrapper
    return func(*args, **kwargs)
  File "/home/dlvm/code/3D-R2N2/lib/data_process.py", line 145, in run
    im = self.load_img(category, model_id, image_id)
  File "/home/dlvm/code/3D-R2N2/lib/data_process.py", line 165, in load_img
    t_im = preprocess_img(im, self.train)
  File "/home/dlvm/code/3D-R2N2/lib/data_augmentation.py", line 65, in preprocess_img
    t_im = crop_center(im_rgb, cfg.CONST.IMG_H, cfg.CONST.IMG_W)
  File "/home/dlvm/code/3D-R2N2/lib/data_augmentation.py", line 36, in crop_center
    return im[top:bottom, left:right]
TypeError: slice indices must be integers or None or have an __index__ method
[INFO/ReconstructionDataProcess-2] process shutting down
[INFO/ReconstructionDataProcess-2] process exiting with exitcode 0
```

The problem is easily solved by the integer division operator `//`.