### PR TITLE
Optional Surface Only View Parameter

### DIFF
--- a/lib/voxel.py
+++ b/lib/voxel.py
@@ -11,7 +11,7 @@ def evaluate_voxel_prediction(preds, gt, thresh):
     return np.array([diff, intersection, union, num_fp, num_fn])
 
 
-def voxel2mesh(voxels, surface_only = True):
+def voxel2mesh(voxels, surface_view):
     cube_verts = [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0],
                   [1, 1, 1]]  # 8 points
 
@@ -27,10 +27,10 @@ def voxel2mesh(voxels, surface_only = True):
     faces = []
     curr_vert = 0
 
-    positions = np.where(voxels > 0)
+    positions = np.where(voxels > 0.3)
     voxels[positions] = 1 
     for i,j,k in zip(*positions):
-        if not surface_only or np.sum(voxels[i-1:i+2,j-1:j+2,k-1:k+2])< 27: # identifies if current voxel has an exposed face 
+        if not surface_view or np.sum(voxels[i-1:i+2,j-1:j+2,k-1:k+2])< 27: # identifies if current voxel has an exposed face 
             verts.extend(scale * (cube_verts + cube_dist_scale * np.array([[i, j, k]])))
             faces.extend(cube_faces + curr_vert)
             curr_vert += len(cube_verts)  
@@ -52,6 +52,6 @@ def write_obj(filename, verts, faces):
             f.write('f %d %d %d\n' % tuple(face))
 
 
-def voxel2obj(filename, pred):
-    verts, faces = voxel2mesh(pred)
+def voxel2obj(filename, pred, surface_view = True):
+    verts, faces = voxel2mesh(pred, surface_view)
     write_obj(filename, verts, faces)

--- a/lib/voxel.py
+++ b/lib/voxel.py
@@ -21,8 +21,6 @@ def voxel2mesh(voxels, surface_only = True):
     cube_verts = np.array(cube_verts)
     cube_faces = np.array(cube_faces) + 1
 
-   
-
     scale = 0.01
     cube_dist_scale = 1.1
     verts = []

--- a/lib/voxel.py
+++ b/lib/voxel.py
@@ -27,7 +27,7 @@ def voxel2mesh(voxels, surface_only = True):
     faces = []
     curr_vert = 0
 
-    positions = np.where(voxels > 0.3)
+    positions = np.where(voxels > 0)
     voxels[positions] = 1 
     for i,j,k in zip(*positions):
         if np.sum(voxels[i-1:i+2,j-1:j+2,k-1:k+2])< 27  or not surface_only: # identifies if current voxel has an exposed face 

--- a/lib/voxel.py
+++ b/lib/voxel.py
@@ -11,7 +11,7 @@ def evaluate_voxel_prediction(preds, gt, thresh):
     return np.array([diff, intersection, union, num_fp, num_fn])
 
 
-def voxel2mesh(voxels):
+def voxel2mesh(voxels, surface_only = True):
     cube_verts = [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0],
                   [1, 1, 1]]  # 8 points
 
@@ -21,22 +21,22 @@ def voxel2mesh(voxels):
     cube_verts = np.array(cube_verts)
     cube_faces = np.array(cube_faces) + 1
 
-    l, m, n = voxels.shape
+   
 
     scale = 0.01
     cube_dist_scale = 1.1
     verts = []
     faces = []
     curr_vert = 0
-    for i in range(l):
-        for j in range(m):
-            for k in range(n):
-                # If there is a non-empty voxel
-                if voxels[i, j, k] > 0:
-                    verts.extend(scale * (cube_verts + cube_dist_scale * np.array([[i, j, k]])))
-                    faces.extend(cube_faces + curr_vert)
-                    curr_vert += len(cube_verts)
 
+    positions = np.where(voxels > 0.3)
+    voxels[positions] = 1 
+    for i,j,k in zip(*positions):
+        if np.sum(voxels[i-1:i+2,j-1:j+2,k-1:k+2])< 27  or not surface_only: # identifies if current voxel has an exposed face 
+            verts.extend(scale * (cube_verts + cube_dist_scale * np.array([[i, j, k]])))
+            faces.extend(cube_faces + curr_vert)
+            curr_vert += len(cube_verts)  
+              
     return np.array(verts), np.array(faces)
 
 

--- a/lib/voxel.py
+++ b/lib/voxel.py
@@ -30,7 +30,7 @@ def voxel2mesh(voxels, surface_only = True):
     positions = np.where(voxels > 0)
     voxels[positions] = 1 
     for i,j,k in zip(*positions):
-        if np.sum(voxels[i-1:i+2,j-1:j+2,k-1:k+2])< 27  or not surface_only: # identifies if current voxel has an exposed face 
+        if not surface_only or np.sum(voxels[i-1:i+2,j-1:j+2,k-1:k+2])< 27: # identifies if current voxel has an exposed face 
             verts.extend(scale * (cube_verts + cube_dist_scale * np.array([[i, j, k]])))
             faces.extend(cube_faces + curr_vert)
             curr_vert += len(cube_verts)  


### PR DESCRIPTION
Added an option in voxel2obj which by default only saves the voxels found the the model's surface . This speeds up viewing in MeshLab considerably for large models. 